### PR TITLE
remove not relevant changelog entry 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] 
 
-## [1.0.1] - 2024-12-1
-
-### Fixed
-
-- Fix naming from mass concentration to number concentration for read number concentration method (returned values were correct).
 ## [1.0.0] - 2024-11-25
 
 ### Added
@@ -26,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add interfaces to start, stop and read measurements.
 - Add interfaces to read product name, serial number and version
 
-[Unreleased]: https://github.com/Sensirion/embedded-i2c-sen66/compare/1.0.1...HEAD
-[1.0.1]: https://github.com/Sensirion/embedded-i2c-sen66/compare/1.0.0...1.0.1
+[Unreleased]: https://github.com/Sensirion/embedded-i2c-sen66/compare/1.0.0...HEAD
 [1.0.0]: https://github.com/Sensirion/embedded-i2c-sen66/compare/0.1.0...1.0.0
 [0.1.0]: https://github.com/Sensirion/embedded-i2c-sen66/releases/tag/0.1.0


### PR DESCRIPTION
as the number concentration method that was fixed
for the other SEN6x drivers is not relevant for
the embedded target, remove this bugfix version again